### PR TITLE
Cruzar el email de la cuenta social con el email del usuario local

### DIFF
--- a/decide/authentication/adapters.py
+++ b/decide/authentication/adapters.py
@@ -5,11 +5,26 @@ from .models import CustomUser
 
 class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
     def pre_social_login(self, request, sociallogin):
-        user = sociallogin.user
-        if user.id:
-            return
+        social_email = sociallogin.account.extra_data.get('email')
+
         try:
-            customer = CustomUser.objects.get(email=user.email)  # if user exists, connect the account to the existing account and login
+            customer = CustomUser.objects.get(email=social_email)  # if user exists, connect the account to the existing account and login
+            sociallogin.state['process'] = 'connect'
+            perform_login(request, customer, 'none')
+        except CustomUser.DoesNotExist:
+            pass
+
+        try:
+            customer = CustomUser.objects.get(email1=social_email)  # if user exists, connect the account to the existing account and login
+            # sociallogin.state['process'] = 'connect'
+            # perform_login(request, customer, 'none')
+            if not sociallogin.is_existing:
+                sociallogin.connect(request, customer)
+        except CustomUser.DoesNotExist:
+            pass
+
+        try:
+            customer = CustomUser.objects.get(email2=social_email)  # if user exists, connect the account to the existing account and login
             sociallogin.state['process'] = 'connect'
             perform_login(request, customer, 'none')
         except CustomUser.DoesNotExist:

--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -149,6 +149,16 @@ DATABASES = {
 SOCIALACCOUNT_ADAPTER = 'authentication.adapters.CustomSocialAccountAdapter'
 AUTH_USER_MODEL = 'authentication.CustomUser'
 
+SOCIALACCOUNT_PROVIDERS = {
+    'github': {
+        'SCOPE': [
+            'user',
+            'repo',
+            'read:org',
+        ],
+    }
+}
+
 # Password validation
 # https://docs.djangoproject.com/en/2.0/ref/settings/#auth-password-validators
 


### PR DESCRIPTION
Lógica para linkar la cuenta de email pública asociada a la red social
con la cuenta de email local